### PR TITLE
Default value of HtsFormat should be UNKNOWN instead of SAM

### DIFF
--- a/src/main/proto/org/phenopackets/schema/v1/core/base.proto
+++ b/src/main/proto/org/phenopackets/schema/v1/core/base.proto
@@ -382,12 +382,13 @@ message File {
 message HtsFile {
 
     enum HtsFormat {
-        SAM = 0;
-        BAM = 1;
-        CRAM = 2;
-        VCF = 3;
-        BCF = 4;
-        GVCF = 5;
+        UNKNOWN = 0;
+        SAM = 1;
+        BAM = 2;
+        CRAM = 3;
+        VCF = 4;
+        BCF = 5;
+        GVCF = 6;
     }
 
     HtsFormat hts_format = 1;


### PR DESCRIPTION
The default value of `HtsFile | HtsFormat` enum is `SAM` at the moment. This default value will also be set if user forgets to set the real value. We should be able to check if user forgot to set the proper value or if the `SAM` is actually correct. Therefore I suggest adding an `UNKNOWN` value and assigning it to the default descriptor.