### PR TITLE
fixed error in java.rst in docs - print did not work

### DIFF
--- a/docs/java.rst
+++ b/docs/java.rst
@@ -157,9 +157,10 @@ the following commands
 
 .. code-block:: java
 
-   Phenopacket phenoPacket = new PhenoPacketExample().spherocytosisExample();
-   try {
-     System.out.println(toJson(phenoPacket));
-     } catch (IOException e) {
-       e.printStackTrace();
-     }
+   Phenopacket p = spherocytosisExample();
+        String jsonString = JsonFormat.printer().includingDefaultValueFields().print(p);
+        try {
+            System.out.println(jsonString);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }

--- a/docs/java.rst
+++ b/docs/java.rst
@@ -157,9 +157,9 @@ the following commands
 
 .. code-block:: java
 
-   Phenopacket p = spherocytosisExample();
-        String jsonString = JsonFormat.printer().includingDefaultValueFields().print(p);
+        Phenopacket p = spherocytosisExample();
         try {
+            String jsonString = JsonFormat.printer().includingDefaultValueFields().print(p);
             System.out.println(jsonString);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION

The JSON print example at the end of the java.rst page in docs was incorrect - there is no obvious "toJson" procedure. The revised version seems to work. 