### PR TITLE
Implementing Linday's copy edits

### DIFF
--- a/docs/age.rst
+++ b/docs/age.rst
@@ -35,7 +35,7 @@ less precise strings will be preferred for privacy reasons, e.g., P40Y.
 age
 ~~~
 
-It is possible to represent age using a string that should be formated according  as ISO8601
+It is possible to represent age using a string that should be formatted according to ISO8601
 `Duration <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_.
 
 
@@ -45,7 +45,7 @@ It is possible to represent age using a string that should be formated according
 AgeRange
 ========
 
-The AgeRange element is inteded to be used when the age of a subject is represented by a bin, e.g., 5-10 years. Bins
+The AgeRange element is intended to be used when the age of a subject is represented by a bin, e.g., 5-10 years. Bins
 such as this are used in some situations in order to protect the privacy of study participants, whose age is then
 represented by bins such as 45-49 years, 50-54 years, 55-59 years, and so on.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -36,5 +36,5 @@ The terms ‘disease’ and ‘phenotype’ are often conflated. The Phenopacket
 to a phenotypic feature, such as `Arachnodactyly <https://hpo.jax.org/app/browse/term/HP:0001166>`_, that is the
 component of a disease, such as `Marfan syndrome <https://hpo.jax.org/app/browse/disease/OMIM:154700>`_. The
 Phenopacket proposed here is designed to support `deep phenotyping <https://www.ncbi.nlm.nih.gov/pubmed/22504886>`_, a
-process wherein individual components of each phenotype are observed and documented. The phenoptypes may be
+process wherein individual components of each phenotype are observed and documented. The phenotypes may be
 constitutional or those related to a sample (such as from a biopsy).

--- a/docs/cohort.rst
+++ b/docs/cohort.rst
@@ -38,7 +38,7 @@ disease.
    * - hts_files
      - :ref:`rstfile`
      - optional
-     - High-thoughput sequencing files obtained from members of the cohort
+     - High-throughput sequencing files obtained from members of the cohort
    * - meta_data
      - :ref:`rstmetadata`
      - required

--- a/docs/disease.rst
+++ b/docs/disease.rst
@@ -7,7 +7,7 @@ Disease
 The word *phenotype* is used with many different meanings, including "the observable traits of an organism”. In medicine,
 the word can be used with at least two different meanings. It is used to refer to
 some **observed** deviation from normal morphology, physiology, or behavior. In contrast, the *disease* is a diagnosis,
-i.e., and inference or hypothesis about the  cause underlying the observed phenotypic abnormalities. Occasionally,
+i.e., an inference or hypothesis about the  cause underlying the observed phenotypic abnormalities. Occasionally,
 physicians use the word phenotype to refer to a disease, but we do not use this meaning here.
 
 

--- a/docs/fhir.rst
+++ b/docs/fhir.rst
@@ -7,7 +7,7 @@ FHIR Implementation Guide
 Phenopackets on FHIR is a FHIR implementation guide based on the Phenopackets standard. It is meant to be conceptually
 equivalent but not directly interoperable. The guide is hosted at:
 
-https://genomics.ontoserver.csiro.au/phenopackets/
+https://aehrc.github.io/fhir-phenopackets-ig/
 
 Briefly, the phenopacket equivalents to various FHIR resources are as follows:
 

--- a/docs/file.rst
+++ b/docs/file.rst
@@ -19,6 +19,7 @@ Phenopacket can contain its own locally-scope HTS files pertaining to that indiv
 
 HtsFile
 ~~~~~~~
+This message is used for information about a high-throughput file.
 
 .. list-table::
     :widths: 25 50 50 50

--- a/docs/individual.rst
+++ b/docs/individual.rst
@@ -87,7 +87,7 @@ mappings to the sample id in the :ref:`rsthtsfile`.
 In this case the :ref:`rstpedigree` is created by the sending system from whatever source they use and the identifiers
 should be mapped to those `Individual.id` contained in the `Family.proband` and `Family.relatives` phenopackets.
 
-In the case the VCF file, the sending system likely has no control or ability to change the identifiers used for the
+In the case of the VCF file, the sending system likely has no control or ability to change the identifiers used for the
 sample id and it is likely they use different identifiers. It is for this reason the :ref:`rsthtsfile` has a *local*
 mapping field `HtsFile.individual_to_sample_identifiers` where the `Individual.id` can be mapped to the sample id in that
 file.

--- a/docs/interpretation.rst
+++ b/docs/interpretation.rst
@@ -188,7 +188,7 @@ See :ref:`rstmetadata` for further information.
 Diagnosis
 ~~~~~~~~~
 
-The diagnosis element is meant to refer to the disease that is infered to be present in the individual
+The diagnosis element is meant to refer to the disease that is inferred to be present in the individual
 or family being analyzed. The diagnosis can be made by  means of an analysis of the phenotypic or the genomic findings or both.
 The element is optional because if the **resolution_status** is **UNSOLVED** then there is no diagnosis.
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -32,7 +32,7 @@ This element contains structured definitions of the resources and ontologies use
     * - resources
       - list of :ref:`rstresource`
       - required
-      - (See text)
+      - Ontologies used to create the phenopacket
     * - updates
       - list of :ref:`rstupdate`
       - optional
@@ -47,8 +47,8 @@ This element contains structured definitions of the resources and ontologies use
       - (See text)
 
 The `MetaData` element MUST have one :ref:`rstresource` element for each ontology or terminology whose
-terms are used in the Phenopacket. For instance, if a MONDO term is used to specificy the disease and
-HPO terms are used to specificy the phenotypes of a patient, then the `MetaData` element MUST have
+terms are used in the Phenopacket. For instance, if a MONDO term is used to specify the disease and
+HPO terms are used to specify the phenotypes of a patient, then the `MetaData` element MUST have
 one `Resource` element each for MONDO and HPO.
 
 **Example**

--- a/docs/phenotype.rst
+++ b/docs/phenotype.rst
@@ -19,11 +19,11 @@ frequency.
    :header: Field, Type, Status, Description
 
     description, string, optional, human-readable verbiage **NOT** for structured text
-    type, :ref:`rstontologyclass`, required,
+    type, :ref:`rstontologyclass`, required, term denoting the phenotypic feature
     negated, boolean, optional, defaults to `false`
     severity, :ref:`rstontologyclass`, optional, description of the severity of the feature described in `type` representing `HP:0012824  <https://hpo.jax.org/app/browse/term/HP:0012824>`_
     modifier, list of :ref:`rstontologyclass`, optional, representing one or more terms from `HP:0012823 <https://hpo.jax.org/app/browse/term/HP:0012823>`_
-    onset, :ref:`rstontologyclass`, optional, HP:0003674 `HP:0011462  <https://hpo.jax.org/app/browse/term/HP:0011462>`_
+    onset, :ref:`rstontologyclass`, optional, Age at which the features was first observed, e.g., `HP:0011462  <https://hpo.jax.org/app/browse/term/HP:0011462>`_
     evidence, :ref:`Evidence <rstevidence>`, recommended, the evidence for an assertion of the observation of a `type`
 
 **Example**

--- a/docs/protobuf.rst
+++ b/docs/protobuf.rst
@@ -25,7 +25,7 @@ Installing protobuf
 
 The following exercise is not necessary to use phenopackets-schema,
 but is intended to build intuition for how protobuf works.
-We first need to install protobuf (Note that these intructions are for this tutorial only. The maven system will automatically
+We first need to install protobuf (Note that these instructions are for this tutorial only. The maven system will automatically
 pull in protobuf for phenopackets schema). We show one simple way of installing protobuf on a linux system in the following.
 
 1. Download the source code from the `protobuf GitHub page <https://github.com/protocolbuffers/protobuf>`_. Most users should download the latest tar.gz archive from the Release page. Extract the code.
@@ -41,7 +41,7 @@ pull in protobuf for phenopackets schema). We show one simple way of installing 
    sudo ldconfig # refresh shared library cache.
 
 
-You now should check if installation was sucessful
+You now should check if installation was successful
 
 .. code-block:: bash
 
@@ -138,7 +138,7 @@ and add the following to the plugin section
 This is the simplest configuration of the `xolstice plugin <https://www.xolstice.org/protobuf-maven-plugin/usage.html>`_; see the documentation for further information. We have assumed that protoc is installed in /usr/local/bin in the above, and the path may need to be adjusted on your system.
 
 
-Add the protobuf definition to the proto directory. Add a class such as *Main.java* in the /src/main/java/org/example directory (package: org.example). For simplcity, the following code snippets could be written in the main method
+Add the protobuf definition to the proto directory. Add a class such as *Main.java* in the /src/main/java/org/example directory (package: org.example). For simplicity, the following code snippets could be written in the main method
 
 .. code-block:: java
 

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -27,13 +27,13 @@ phenopacket is regarded as malformed. This corresponds to the key words ``MUST``
 
 Validation software must emit an error if a required field is missing. We note that natively protobuf messages never
 return a null pointer, and so if a field is missing it will be an empty string, a zero, or default instance depending
-on the datatype. Therefore, in practive validation software does not need to check for null pointers.
+on the datatype. Therefore, in practice, validation software does not need to check for null pointers.
 
 Recommended
 ===========
 
 A field is not absolutely required, or there are valid reasons in particular circumstances that the field does
-not apply to the intended use case of the Phenopacket. This corresponds to the key woirds ``SHOULD`` and ``RECOMMENDED`` in
+not apply to the intended use case of the Phenopacket. This corresponds to the key words ``SHOULD`` and ``RECOMMENDED`` in
 `RFC2119 <https://www.ietf.org/rfc/rfc2119.txt>`_. For example, a variant may be associated with an id that can
 be useful to have but is not necessary for an analysis. The variant NM_000138.4:c.*2024A>G is associated with the
 id `rs558488257 <https://www.ncbi.nlm.nih.gov/snp/rs558488257>`_.

--- a/docs/resource.rst
+++ b/docs/resource.rst
@@ -21,9 +21,9 @@ The :ref:`rstmetadata` element uses one resource element to describe each resour
    id, string, required, hp
    name, string, required, human phenotype ontology
    namespace_prefix, string, required, HP
-   url, string, required, http://purl.obolibrary.org/obo/hp.owl
+   url, string, required, Uniform Resource Locator of the resource
    version, string, required, 2018-03-08
-   iri_prefix, string, required, http://purl.obolibrary.org/obo/HP_
+   iri_prefix, string, required, Internationalized Resource Identifier (e.g., http://purl.obolibrary.org/obo/HP_)
 
 **Example**
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -18,7 +18,7 @@ data sharing between resources using an agreed upon common schema.
 
 This common schema has been used to define the 'Phenopacket' which is a catch-all collection of data types, specifically
 focused on representing disease data both initial data capture and analysis. The phenopacket schema is designed to be both human
-and machine-readable, and to inter-operate with standards being developed in organizations such as in the `ISO TC215 comittee <https://www.iso.org/committee/7546903.html>`_ and the `HL7 Fast Healthcare Interoperability Resources Specification (aka FHIR®) <http://hl7.org/fhir/>`_.
+and machine-readable, and to inter-operate with standards being developed in organizations such as in the `ISO TC215 committee <https://www.iso.org/committee/7546903.html>`_ and the `HL7 Fast Healthcare Interoperability Resources Specification (aka FHIR®) <http://hl7.org/fhir/>`_.
 
 .. _phenopacket-schema-diagram:
 

--- a/docs/variant.rst
+++ b/docs/variant.rst
@@ -75,7 +75,7 @@ The allele element is required and can be one and only one of ``HgvsAllele``, ``
 HgvsAllele
 ~~~~~~~~~~
 This element is used to describe an allele according to the nomenclature of the
-`Human Geneome Variation Society (HGVS) <http://www.hgvs.org/>`_. For instance,
+`Human Genome Variation Society (HGVS) <http://www.hgvs.org/>`_. For instance,
 ``NM_000226.3:c.470T>G`` indicates that a T at position 470 of the sequence represented by version 3 of
 NM_000226 (which is the mRNA of the human keratin 9 gene `KRT9 <https://www.ncbi.nlm.nih.gov/nuccore/NM_000226.3>`_).
 
@@ -171,7 +171,7 @@ examples.
 The SPDI notation represents variation as deletion of a sequence (D) at a given position (P) in reference sequence (S)
 followed by insertion of a replacement sequence (I) at that same position. Position 0 indicates a deletion that
 starts immediately before the first nucleotide, and position 1 represents a deletion interval that starts between the
-first and second residues, and so on. Either the deleted or the inserted interval can be empty, resulting a pure
+first and second residues, and so on. Either the deleted or the inserted interval can be empty, resulting in a pure
 insertion or deletion.
 
 Note that the deleted and inserted sequences in SPDI are all written on the positive strand for two-stranded molecules.


### PR DESCRIPTION
I did not know what is being referred to here. I have fixed everything else:
```
Variant
https://phenopackets-schema.readthedocs.io/en/1.0.0/variant.html
Data model table, field column - ‘re’ - should be ‘ref’?
Data model table - suggest changing the examples in the description column to short one-line description of fields
Data model table and example underneath - id and chr are swapped in the code - suggest fixing the order of elements in the table to match order in the code
```



