### PR TITLE
Fixing documentation for phenotypes

### DIFF
--- a/docs/phenotype.rst
+++ b/docs/phenotype.rst
@@ -39,7 +39,7 @@ frequency.
             id": "HP:0012825",
             "label": "Mild"
         }
-        "classOfOnset": {
+        "onset": {
           "id": "HP:0003577",
           "label": "Congenital onset"
         }


### PR DESCRIPTION
Small change noticed going through the docs, should be "onset" instead of previous value.