### PR TITLE
ISO Documentation Edits

### DIFF
--- a/docs/biosample.rst
+++ b/docs/biosample.rst
@@ -39,7 +39,7 @@ genomic array as well as RNA-seq experiments) may refer to the same Biosample.
      - required
      - Tissue from which the sample was taken
    * - phenotypic_features
-     - :ref:`rstphenotypicfeature`
+     - :ref:`rstphenotypicfeature` (list)
      - recommended
      - List of phenotypic abnormalities of the sample
    * - taxonomy
@@ -59,9 +59,9 @@ genomic array as well as RNA-seq experiments) may refer to the same Biosample.
      - recommended
      - Indicates primary, metastatic, recurrent
    * - tumor_grade
-     - :ref:`rstontologyclass`
+     - :ref:`rstontologyclass` (list)
      - recommended
-     - List of terms representing the tumor grade
+     - List of terms to indicate the grade of the tumor
    * - diagnostic_markers
      - :ref:`rstontologyclass`
      - recommended
@@ -71,11 +71,11 @@ genomic array as well as RNA-seq experiments) may refer to the same Biosample.
      - required
      - The procedure used to extract the biosample
    * - hts_files
-     - :ref:`rstfile`
+     - :ref:`rstfile` (list)
      - optional
      - list of high-throughput sequencing files derived from the biosample
    * - variants
-     - :ref:`rstvariant`
+     - :ref:`rstvariant` (list)
      - optional
      - List of variants determined to be present in the biosample
    * - is_control_sample

--- a/docs/biosample.rst
+++ b/docs/biosample.rst
@@ -25,15 +25,15 @@ genomic array as well as RNA-seq experiments) may refer to the same Biosample.
    * - id
      - string
      - required
-     - arbitrary identifier
+     - Arbitrary identifier
    * - individual_id
      - string
      - recommended
-     - arbitrary identifier
+     - Arbitrary identifier
    * - description
      - string
      - optional
-     - arbitrary text
+     - Arbitrary text
    * - sampled_tissue
      - :ref:`rstontologyclass`
      - required
@@ -73,7 +73,7 @@ genomic array as well as RNA-seq experiments) may refer to the same Biosample.
    * - hts_files
      - :ref:`rstfile` (list)
      - optional
-     - list of high-throughput sequencing files derived from the biosample
+     - List of high-throughput sequencing files derived from the biosample
    * - variants
      - :ref:`rstvariant` (list)
      - optional
@@ -81,7 +81,7 @@ genomic array as well as RNA-seq experiments) may refer to the same Biosample.
    * - is_control_sample
      - boolean
      - optional (default: false)
-     - whether the sample is being used as a normal control
+     - Whether the sample is being used as a normal control
 
 
 

--- a/docs/cohort.rst
+++ b/docs/cohort.rst
@@ -26,17 +26,17 @@ disease.
    * - id
      - string
      - required
-     - arbitrary identifier
+     - Arbitrary identifier
    * - description
      - string
      - optional
-     - arbitrary text
+     - Arbitrary text
    * - members
-     - :ref:`rstphenopacket`
+     - :ref:`rstphenopacket` (list)
      - required
      - Phenopackets that represent members of the cohort
    * - hts_files
-     - :ref:`rstfile`
+     - :ref:`rstfile` (list)
      - optional
      - High-throughput sequencing files obtained from members of the cohort
    * - meta_data

--- a/docs/disease.rst
+++ b/docs/disease.rst
@@ -20,7 +20,7 @@ physicians use the word phenotype to refer to a disease, but we do not use this 
 
    term, :ref:`rstontologyclass`, required, An ontology class that represents the disease
    onset, :ref:`rstage` or :ref:`rstagerange` or :ref:`rstontologyclass`, optional, an element representing the age of onset of the disease
-   disease_stage, :ref:`rstontologyclass` (list), optional, List of terms representing the disease stage e.g. AJCC stage group.
+   disease_stage, :ref:`rstontologyclass` (list), optional, List of terms representing the disease stage e.g. AJCC stage group, TNM.
    tnm_finding, :ref:`rstontologyclass` (list), optional, List of terms representing the tumor TNM score
 
 

--- a/docs/disease.rst
+++ b/docs/disease.rst
@@ -19,7 +19,7 @@ physicians use the word phenotype to refer to a disease, but we do not use this 
    :align: left
 
    term, :ref:`rstontologyclass`, required, An ontology class that represents the disease
-   onset, :ref:`rstage` or :ref:`rstagerange` or :ref:`rstontologyclass`, optional, an element representing the age of onset of the disease
+   onset, :ref:`rstage` or :ref:`rstagerange` or :ref:`rstontologyclass`, optional, An element representing the age of onset of the disease
    disease_stage, :ref:`rstontologyclass` (list), optional, List of terms representing the disease stage e.g. AJCC stage group
    tnm_finding, :ref:`rstontologyclass` (list), optional, List of terms representing the tumor TNM score
 

--- a/docs/disease.rst
+++ b/docs/disease.rst
@@ -20,8 +20,8 @@ physicians use the word phenotype to refer to a disease, but we do not use this 
 
    term, :ref:`rstontologyclass`, required, An ontology class that represents the disease
    onset, :ref:`rstage` or :ref:`rstagerange` or :ref:`rstontologyclass`, optional, an element representing the age of onset of the disease
-   disease_stage, :ref:`rstontologyclass`, optional, List of terms representing the disease stage e.g. AJCC stage group.
-   tnm_finding, :ref:`rstontologyclass`, optional, List of terms representing the tumor TNM score
+   disease_stage, :ref:`rstontologyclass` (list), optional, List of terms representing the disease stage e.g. AJCC stage group.
+   tnm_finding, :ref:`rstontologyclass` (list), optional, List of terms representing the tumor TNM score
 
 
 
@@ -58,7 +58,7 @@ disease_stage
 ~~~~~~~~~~~
 
 This attribute is used to describe the stage of disease. If the disease is a cancer, this attribute describes
-the extent of cancer development, typically including an AJCC stage group (i.e., Stage 0, I-IV), though other staging
+the extent of cancer development, typically including an AJCC or TNM stage group (i.e., Stage 0, I-IV), though other staging
 systems are used for some cancers. See `staging <https://www.cancer.gov/about-cancer/diagnosis-staging/staging>`_.
 The list of elements constituting this attribute should be derived from child terms of NCIT:C28108 (Disease Stage
 Qualifier) or equivalent hierarchy from another ontology.

--- a/docs/disease.rst
+++ b/docs/disease.rst
@@ -58,7 +58,7 @@ disease_stage
 ~~~~~~~~~~~
 
 This attribute is used to describe the stage of disease. If the disease is a cancer, this attribute describes
-the extent of cancer development, typically including an AJCC (i.e., Stage 0, I-IV), though other staging
+the extent of cancer development, typically including an AJCC stage group (i.e., Stage 0, I-IV), though other staging
 systems are used for some cancers. See `staging <https://www.cancer.gov/about-cancer/diagnosis-staging/staging>`_.
 The list of elements constituting this attribute should be derived from child terms of NCIT:C28108 (Disease Stage
 Qualifier) or equivalent hierarchy from another ontology.

--- a/docs/disease.rst
+++ b/docs/disease.rst
@@ -20,7 +20,7 @@ physicians use the word phenotype to refer to a disease, but we do not use this 
 
    term, :ref:`rstontologyclass`, required, An ontology class that represents the disease
    onset, :ref:`rstage` or :ref:`rstagerange` or :ref:`rstontologyclass`, optional, an element representing the age of onset of the disease
-   disease_stage, :ref:`rstontologyclass` (list), optional, List of terms representing the disease stage e.g. AJCC stage group, TNM.
+   disease_stage, :ref:`rstontologyclass` (list), optional, List of terms representing the disease stage e.g. AJCC stage group
    tnm_finding, :ref:`rstontologyclass` (list), optional, List of terms representing the tumor TNM score
 
 
@@ -58,7 +58,7 @@ disease_stage
 ~~~~~~~~~~~
 
 This attribute is used to describe the stage of disease. If the disease is a cancer, this attribute describes
-the extent of cancer development, typically including an AJCC or TNM stage group (i.e., Stage 0, I-IV), though other staging
+the extent of cancer development, typically including an AJCC (i.e., Stage 0, I-IV), though other staging
 systems are used for some cancers. See `staging <https://www.cancer.gov/about-cancer/diagnosis-staging/staging>`_.
 The list of elements constituting this attribute should be derived from child terms of NCIT:C28108 (Disease Stage
 Qualifier) or equivalent hierarchy from another ontology.

--- a/docs/family.rst
+++ b/docs/family.rst
@@ -50,7 +50,7 @@ with the :ref:`rstpedigree` element.
    * - hts_files
      - :ref:`rstfile` (list)
      - optional
-     - list of high-throughput sequencing files
+     - High-throughput sequencing files obtained from members of the family 
    * - meta_data
      - :ref:`rstmetadata`
      - required

--- a/docs/family.rst
+++ b/docs/family.rst
@@ -34,7 +34,7 @@ with the :ref:`rstpedigree` element.
    * - id
      - string
      - required
-     - application-specific identifier
+     - Application-specific identifier
    * - proband
      - :ref:`rstphenopacket`
      - required
@@ -42,11 +42,11 @@ with the :ref:`rstpedigree` element.
    * - relatives
      - :ref:`rstphenopacket` (list)
      - optional
-     - list of Phenopackets for family members other than the proband
+     - List of Phenopackets for family members other than the proband
    * - pedigree
      - :ref:`rstpedigree`
      - required
-     - representation of the pedigree
+     - Representation of the pedigree
    * - hts_files
      - :ref:`rstfile` (list)
      - optional

--- a/docs/file.rst
+++ b/docs/file.rst
@@ -44,7 +44,7 @@ This message is used for information about a high-throughput file.
     * - genome_assembly
       - string
       - required
-      - e.g. GRCh38
+      - The genome assembly used (e.g. GRCh38)
     * - individual_to_sample_identifiers
       - a map of string key: value
       - recommended

--- a/docs/file.rst
+++ b/docs/file.rst
@@ -36,11 +36,11 @@ This message is used for information about a high-throughput file.
     * - description
       - string
       - optional
-      - arbitrary description of the file
+      - Arbitrary description of the file
     * - hts_format
       - :ref:`rsthtsformat`
       - required
-      - VCF
+      - Indicates the format of the HTS file
     * - genome_assembly
       - string
       - required

--- a/docs/individual.rst
+++ b/docs/individual.rst
@@ -23,9 +23,9 @@ we explain the element using the example of a human proband in a clinical invest
       - required
       - An arbitrary identifier
     * - alternate_ids
-      - a list of :ref:`rstcurie`
+      - :ref:`rstcurie` (list)
       - optional
-      - A list of alternative identifiers for the individual
+      - Alternative identifiers for the individual
     * - date_of_birth
       - timestamp
       - optional

--- a/docs/individual.rst
+++ b/docs/individual.rst
@@ -45,7 +45,7 @@ we explain the element using the example of a human proband in a clinical invest
     * - taxonomy
       - :ref:`rstontologyclass`
       - optional
-      - an :ref:`rstontologyclass` representing the species (e.g., NCBITaxon:9615)
+      - An :ref:`rstontologyclass` representing the species (e.g., NCBITaxon:9615)
 
 
 **Example**

--- a/docs/interpretation.rst
+++ b/docs/interpretation.rst
@@ -5,6 +5,8 @@ Interpretation
 This message intends to represent the interpretation of a genomic analysis, such as the report from
 a diagnostic laboratory.
 
+The Interpretation message contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of Phenopacket building block elements, but the additional elements described in this section are only used to compose the Interpretation.
+
 **Data model**
 
  .. list-table::
@@ -28,8 +30,8 @@ a diagnostic laboratory.
       - required
       - The subject of this interpretation
     * - diagnosis
-      - :ref:`rstdiagnosis`
-      - repeated
+      - :ref:`rstdiagnosis` (list)
+      - optional
       - One or more diagnoses, if made
     * - meta_data
       - See :ref:`rstmetadata`
@@ -207,8 +209,8 @@ The element is optional because if the **resolution_status** is **UNSOLVED** the
       - required
       - The diagnosed condition
     * - genomic_interpretations
-      - :ref:`rstgenomicinterpretation`
-      - repeated
+      - :ref:`rstgenomicinterpretation` (list)
+      - optional
       - The genomic elements assessed as being responsible for the disease or empty
 
 **Example**

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -30,21 +30,21 @@ This element contains structured definitions of the resources and ontologies use
       - optional
       - Name of person who submitted the phenopacket
     * - resources
-      - list of :ref:`rstresource`
+      - :ref:`rstresource` (list)
       - required
       - Ontologies used to create the phenopacket
     * - updates
-      - list of :ref:`rstupdate`
+      - :ref:`rstupdate` (list)
       - optional
       - List of updates to the phenopacket
     * - phenopacket_schema_version
       - string
       - optional
-      - schema version of the current phenopacket
+      - Schema version of the current phenopacket
     * - external_references
-      - List of :ref:`rstexternalreference`
+      - :ref:`rstexternalreference` (list)
       - optional
-      - (See text)
+      - A list of ExternalReference
 
 The `MetaData` element MUST have one :ref:`rstresource` element for each ontology or terminology whose
 terms are used in the Phenopacket. For instance, if a MONDO term is used to specify the disease and

--- a/docs/ontologyclass.rst
+++ b/docs/ontologyclass.rst
@@ -19,8 +19,8 @@ term.
 .. csv-table::
    :header: Field, Type, Status, Description
 
-    id, string, required, a CURIE-style identifier e.g. HP:0001875
-    label, string, required, human-readable class name e.g. Neutropenia
+    id, string, required, A CURIE-style identifier e.g. HP:0001875
+    label, string, required, A human-readable class name e.g. Neutropenia
 
 
 **Example**

--- a/docs/pedigree.rst
+++ b/docs/pedigree.rst
@@ -27,7 +27,7 @@ sequences of members of a family, some of whom are affected by a Mendelian disea
      - Status
      - Description
    * - persons
-     - list of :ref:`rstperson`
+     - :ref:`rstperson` (list)
      - required
      - list of family members in this pedigree
 

--- a/docs/pedigree.rst
+++ b/docs/pedigree.rst
@@ -29,7 +29,7 @@ sequences of members of a family, some of whom are affected by a Mendelian disea
    * - persons
      - :ref:`rstperson` (list)
      - required
-     - list of family members in this pedigree
+     - List of family members in this pedigree
 
 
 The pedigree is simply a list of Person objects. These objects are meant to reflect the elements of
@@ -52,27 +52,27 @@ Person
    * - family_id
      - string
      - required
-     - application specific identifier
+     - Application specific identifier
    * - individual_id
      - string
      - required
-     - application specific identifier
+     - Application specific identifier
    * - paternal_id
      - string
      - required
-     - application specific identifier
+     - Application specific identifier
    * - maternal_id
      - string
      - required
-     - application specific identifier
+     - Application specific identifier
    * - sex
      - :ref:`rstsex`
      - required
-     - see text
+     - See text
    * - affected_status
      - :ref:`rstaffectedstatus`
      - required
-     - see text
+     - See text
 
 
 **Example**

--- a/docs/phenopacket.rst
+++ b/docs/phenopacket.rst
@@ -4,7 +4,7 @@
 Phenopacket
 ===========
 
-A Phenopacket is an anonymous phenotypic description of an individual or biosample with potential genes of interest
+A Phenopacket is an anonymized phenotypic description of an individual or biosample with potential genes of interest
 and/or diagnoses. It can be used for multiple use cases. For instance, it can be used to describe the
 phenotypic findings observed in an individual with a disease that is being studied or for an individual in
 whom the diagnosis is being sought. The phenopacket can contain information about
@@ -31,7 +31,7 @@ describe the phenotypic abnormalities directly associated with an extirpated or 
       - recommended
       - The proband
     * - phenotypic_features
-      - List of :ref:`phenotypicfeature`
+      - :ref:`phenotypicfeature` (list)
       - recommended
       - Phenotypic features observed in the proband
     * - biosamples
@@ -43,17 +43,17 @@ describe the phenotypic abnormalities directly associated with an extirpated or 
       - optional
       - Gene deemed to be relevant to the case (application specific)
     * - variants
-      - List of :ref:`rstvariant`
+      - :ref:`rstvariant` (list)
       - optional
       - Variants identified in the proband
     * - diseases
-      - List of :ref:`rstdisease`
+      - :ref:`rstdisease` (list)
       - optional
       - Disease(s) diagnosed in the proband
     * - hts_files
-      - List of :ref:`rstfile`
+      - :ref:`rstfile` (list)
       - optional
-      - VCF or other high-throughput sequencing files
+      - High-throughput sequencing files (ie. VCF)
     * - meta_data
       - :ref:`rstmetadata`
       - required

--- a/docs/phenopacket.rst
+++ b/docs/phenopacket.rst
@@ -53,7 +53,7 @@ describe the phenotypic abnormalities directly associated with an extirpated or 
     * - hts_files
       - :ref:`rstfile` (list)
       - optional
-      - High-throughput sequencing files (ie. VCF)
+      - High-throughput sequencing files (e.g. VCF)
     * - meta_data
       - :ref:`rstmetadata`
       - required

--- a/docs/phenopacket.rst
+++ b/docs/phenopacket.rst
@@ -25,7 +25,7 @@ describe the phenotypic abnormalities directly associated with an extirpated or 
     * - id
       - string
       - required
-      - arbitrary identifier
+      - Arbitrary identifier
     * - subject
       - :ref:`rstindividual`
       - recommended
@@ -37,7 +37,7 @@ describe the phenotypic abnormalities directly associated with an extirpated or 
     * - biosamples
       - :ref:`rstbiosample`
       - optional
-      - samples (e.g., biopsies), if any
+      - Samples (e.g., biopsies), if any
     * - genes
       - :ref:`rstgene`
       - optional

--- a/docs/phenotype.rst
+++ b/docs/phenotype.rst
@@ -22,7 +22,7 @@ frequency.
     type, :ref:`rstontologyclass`, required, term denoting the phenotypic feature
     negated, boolean, optional, defaults to `false`
     severity, :ref:`rstontologyclass`, optional, description of the severity of the feature described in `type` representing `HP:0012824  <https://hpo.jax.org/app/browse/term/HP:0012824>`_
-    modifier, list of :ref:`rstontologyclass`, optional, representing one or more terms from `HP:0012823 <https://hpo.jax.org/app/browse/term/HP:0012823>`_
+    modifier, :ref:`rstontologyclass` (list), optional, representing one or more terms from `HP:0012823 <https://hpo.jax.org/app/browse/term/HP:0012823>`_
     onset, :ref:`rstontologyclass`, optional, Age at which the features was first observed, e.g., `HP:0011462  <https://hpo.jax.org/app/browse/term/HP:0011462>`_
     evidence, :ref:`Evidence <rstevidence>`, recommended, the evidence for an assertion of the observation of a `type`
 

--- a/docs/phenotype.rst
+++ b/docs/phenotype.rst
@@ -18,13 +18,13 @@ frequency.
 .. csv-table::
    :header: Field, Type, Status, Description
 
-    description, string, optional, human-readable verbiage **NOT** for structured text
-    type, :ref:`rstontologyclass`, required, term denoting the phenotypic feature
-    negated, boolean, optional, defaults to `false`
-    severity, :ref:`rstontologyclass`, optional, description of the severity of the feature described in `type` representing `HP:0012824  <https://hpo.jax.org/app/browse/term/HP:0012824>`_
-    modifier, :ref:`rstontologyclass` (list), optional, representing one or more terms from `HP:0012823 <https://hpo.jax.org/app/browse/term/HP:0012823>`_
+    description, string, optional, Human-readable verbiage **NOT** for structured text
+    type, :ref:`rstontologyclass`, required, Term denoting the phenotypic feature
+    negated, boolean, optional, Defaults to `false`
+    severity, :ref:`rstontologyclass`, optional, Description of the severity of the feature described in `type` representing `HP:0012824  <https://hpo.jax.org/app/browse/term/HP:0012824>`_
+    modifier, :ref:`rstontologyclass` (list), optional, Representing one or more terms from `HP:0012823 <https://hpo.jax.org/app/browse/term/HP:0012823>`_
     onset, :ref:`rstontologyclass`, optional, Age at which the features was first observed, e.g., `HP:0011462  <https://hpo.jax.org/app/browse/term/HP:0011462>`_
-    evidence, :ref:`Evidence <rstevidence>`, recommended, the evidence for an assertion of the observation of a `type`
+    evidence, :ref:`Evidence <rstevidence>`, recommended, The evidence for an assertion of the observation of a `type`
 
 **Example**
 

--- a/docs/procedure.rst
+++ b/docs/procedure.rst
@@ -14,8 +14,8 @@ body_site element if needed.
 .. csv-table::
    :header: Field, Type, Status, Description
 
-    code, :ref:`rstontologyclass`, required, clinical procedure performed on a subject
-    body_site, :ref:`rstontologyclass`, optional, specific body site if unable to represent this is the :ref:`procedurecode`
+    code, :ref:`rstontologyclass`, required, Clinical procedure performed on a subject
+    body_site, :ref:`rstontologyclass`, optional, Specific body site if unable to represent this is the :ref:`procedurecode`
 
 **Example**
 

--- a/docs/resource.rst
+++ b/docs/resource.rst
@@ -23,7 +23,7 @@ The :ref:`rstmetadata` element uses one resource element to describe each resour
    url, string, required, Uniform Resource Locator of the resource
    version, string, required, The version of the resource or ontology used to make the annotation
    namespace_prefix, string, required, The prefix used in the CURIE of an OntologyClass
-   iri_prefix, string, required, The full Internationalized Resource Identifier (IRI) prefix (e.g., http://purl.obolibrary.org/obo/HP_)
+   iri_prefix, string, required, The full Internationalized Resource Identifier (IRI) prefix (e.g. http://purl.obolibrary.org/obo/HP_)
 
 **Example**
 

--- a/docs/resource.rst
+++ b/docs/resource.rst
@@ -18,12 +18,12 @@ The :ref:`rstmetadata` element uses one resource element to describe each resour
 .. csv-table::
    :header: Field, Type, Status, Description
 
-   id, string, required, hp
-   name, string, required, human phenotype ontology
-   namespace_prefix, string, required, HP
+   id, string, required, OBO ID representing the resource
+   name, string, required, The name of the ontology referred to by the id element
    url, string, required, Uniform Resource Locator of the resource
-   version, string, required, 2018-03-08
-   iri_prefix, string, required, Internationalized Resource Identifier (e.g., http://purl.obolibrary.org/obo/HP_)
+   version, string, required, The version of the resource or ontology used to make the annotation
+   namespace_prefix, string, required, The prefix used in the CURIE of an OntologyClass
+   iri_prefix, string, required, The full Internationalized Resource Identifier (IRI) prefix (e.g., http://purl.obolibrary.org/obo/HP_)
 
 **Example**
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -26,7 +26,8 @@ Overview
 ~~~~~~~~
 
 The diagram below shows an overview of Phenopackets schema elements and relationships. The orange circles represent an Interpretation and its sub-elements. Blue circles are the top-level elements used to describe an individual or group of individuals, and the green circles are the building block components. Lines between elements indicate composition.
-Note: Interpretation is displayed in a different colour from the other top-level elements because it contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of the green building block elements, but the additional orange elements are only used to compose the Interpretation. 
+
+**Note:** Interpretation is displayed in a different colour from the other top-level elements because it contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of the green building block elements, but the additional orange elements are only used to compose the Interpretation. 
 
 .. figure:: graph/phenopacket-schema-v1.svg
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -25,10 +25,12 @@ and machine-readable, and to inter-operate with standards being developed in org
 Overview
 ~~~~~~~~
 
-The diagram below shows an overview of Phenopackets schema elements and relationships. The orange circles represent an Interpretation and its sub-elements. Blue circles are the top-level elements used to describe an individual or group of individuals, and the green circles are the building block components. Lines between elements indicate composition.
-
-**Note:** Interpretation is displayed in a different colour from the other top-level elements because it contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of the green building block elements, but the additional orange elements are only used to compose the Interpretation. 
+The diagram below shows an overview of Phenopackets schema elements and relationships.
 
 .. figure:: graph/phenopacket-schema-v1.svg
+
+The yellow circles represent an Interpretation and its sub-elements. Blue circles are the top-level elements used to describe an individual or group of individuals, and the green circles are the building block components of those. Lines between elements indicate composition.
+
+**Note:** Interpretation is displayed in a different colour from the other top-level elements because it contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of the green building block elements, but the additional orange elements are only used to compose the Interpretation. 
 
 The schema is defined in protobuf. You can find out more in the section ':ref:`rstprotobuf`'.

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -25,7 +25,8 @@ and machine-readable, and to inter-operate with standards being developed in org
 Overview
 ~~~~~~~~
 
-The diagram below shows an overview of the schema elements.
+The diagram below shows an overview of Phenopackets schema elements and relationships. The orange circles represent an Interpretation and its sub-elements. Blue circles are the top-level elements used to describe an individual or group of individuals, and the green circles are the building block components. Lines between elements indicate composition.
+Note: Interpretation is displayed in a different colour from the other top-level elements because it contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of the green building block elements, but the additional orange elements are only used to compose the Interpretation. 
 
 .. figure:: graph/phenopacket-schema-v1.svg
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -29,7 +29,7 @@ The diagram below shows an overview of Phenopackets schema elements and relation
 
 .. figure:: graph/phenopacket-schema-v1.svg
 
-The yellow circles represent an Interpretation and its sub-elements. Blue circles are the top-level elements used to describe an individual or group of individuals, and the green circles are the building block components of those. Lines between elements indicate composition.
+*The yellow circles represent an Interpretation and its sub-elements. Blue circles are the top-level elements used to describe an individual or group of individuals, and the green circles are the building block components of those. Lines between elements indicate composition.*
 
 **Note:** Interpretation is displayed in a different colour from the other top-level elements because it contains a Family or Phenopacket. Interpretation interprets the Phenopacket based on its component elements, whereas the Phenopacket simply states what was observed. They are both composed of the green building block elements, but the additional orange elements are only used to compose the Interpretation. 
 

--- a/docs/sex.rst
+++ b/docs/sex.rst
@@ -18,8 +18,8 @@ be specified.
    :header: Name, Ordinal, Description
 
     UNKNOWN_SEX, 0, Not assessed or not available. Maps to `NCIT:C17998 <https://www.ebi.ac.uk/ols/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C17998>`_
-    FEMALE, 1, female sex. Maps to `NCIT:C46113 <https://www.ebi.ac.uk/ols/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C46113>`_
-    MALE, 2, male sex. Maps to `NCIT:C46112 <https://www.ebi.ac.uk/ols/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C46112>`_
+    FEMALE, 1, Female sex. Maps to `NCIT:C46113 <https://www.ebi.ac.uk/ols/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C46113>`_
+    MALE, 2, Male sex. Maps to `NCIT:C46112 <https://www.ebi.ac.uk/ols/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C46112>`_
     OTHER_SEX, 3, It is not possible to accurately assess the applicability of MALE/FEMALE. Maps to `NCIT:C45908 <https://www.ebi.ac.uk/ols/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C45908>`_
 
 **Example**

--- a/docs/variant.rst
+++ b/docs/variant.rst
@@ -32,8 +32,8 @@ field. It is RECOMMENDED to use a :ref:`rstcurie` identifier and corresponding :
 .. csv-table::
    :header: Field, Type, Status, Description
 
-    allele, :ref:`Allele`, required, one of the Allele types described below
-    zygosity, :ref:`rstontologyclass` , recommended, See :ref:`zygosity` below
+    allele, :ref:`Allele`, required, One of the Allele types described below: HgvsAllele, VcfAlelle, SpdiAllele or IcsnAllele
+    zygosity, :ref:`rstontologyclass` , recommended, The :ref:`zygosity` of the variant as determined in all of the samples
 
 
 **Example**
@@ -90,7 +90,7 @@ HGVS nomenclature.
    :header: Field, Type, Status, Description
 
     id, string, recommended, An arbitrary identifier
-    hgvs, string, required, NM_000226.3:c.470T>G
+    hgvs, string, required, Variant represented in hgvs nomenclature (e.g. NM_000226.3:c.470T>G)
 
 **Example**
 
@@ -123,10 +123,10 @@ Phenopacket will report the contents of the info field for single nucleotide and
 .. csv-table::
    :header: Field, Type, Status, Description
 
-    genome_assembly, string, required, The reference genome identifier e.g. GRCh38
+    genome_assembly, string, required, The reference genome identifier (e.g. GRCh38)
     id, string, recommended, An arbitrary identifier
-    chr, string, required, A chromosome identifier e.g. chr2 or 2
-    pos, int32, required, The 1-based genomic position e.g. 134327882
+    chr, string, required, A chromosome identifier (e.g. chr2 or 2)
+    pos, int32, required, The 1-based genomic position (e.g. 134327882)
     ref, string, required, The reference base(s)
     alt, string, required, The alternate base(s)
     info, string, optional, Relevant parts of the INFO field
@@ -182,10 +182,10 @@ Note that the deleted and inserted sequences in SPDI are all written on the posi
    :header: Field, Type, Status, Description
 
     id, string, recommended, An arbitrary identifier
-    seq_id, string, required, Seq1
-    position, int32, required, 4
-    deleted_sequence, string, required, A
-    inserted_sequence, string, required, G
+    seq_id, string, required, The reference sequence (e.g. Seq1)
+    position, int32, required, A 0-based coordinate for where the Deleted Sequence starts (e.g. 4)
+    deleted_sequence, string, required, Sequence of the deletion (e.g. A)
+    inserted_sequence, string, required, Sequence of the insertion (e.g. G)
 
 **Example**
 
@@ -217,7 +217,7 @@ del(6)(q23q24) describes a deletion from band q23 to q24 on chromosome 6.
    :header: Field, Type, Status, Description
 
    id, string, recommended, An arbitrary identifier
-   iscn, string, required, t(8;9;11)(q12;p24;p12)
+   iscn, string, required, ISCN representation of the variant e.g. t(8;9;11)(q12;p24;p12)
 
 **Example**
 


### PR DESCRIPTION
Documentation edits from the ISO review process. Main edits include:
- Addition of '(list)' label where appropriate
- Addition of Interpretation clarification to match the one added to the element overview figure
- Changes to the description column in some tables
- 'repeated' in Status column of diagnosis and genomic interpretation changed to 'optional'