### PR TITLE
Removing Protobuf version due to error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-protobuf==3.7.1
+protobuf
 xmltodict==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-protobuf
+protobuf==3.15.0
 xmltodict==0.12.0


### PR DESCRIPTION
The `protobuf` version (3.7.1) is causing the following error:

`AttributeError: module 'google.protobuf.descriptor' has no attribute '_internal_create_key'`

Removing the version allowing the newest version of `protobuf` to be used fixes it, and is referenced in [this post](https://stackoverflow.com/questions/61922334/how-to-solve-attributeerror-module-google-protobuf-descriptor-has-no-attribu)