### PR TITLE
Add `module-info.java` file

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module phenopacket.schema {
+module org.phenopackets.schema {
     requires com.google.protobuf;
 
     exports org.phenopackets.schema.v1;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module phenopacket.schema {
+    requires com.google.protobuf;
+
+    exports org.phenopackets.schema.v1;
+    exports org.phenopackets.schema.v1.core;
+
+    exports org.phenopackets.schema.v2;
+    exports org.phenopackets.schema.v2.core;
+
+    exports org.ga4gh.vrs.v1;
+    exports org.ga4gh.vrsatile.v1;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module org.phenopackets.schema {
-    requires com.google.protobuf;
+    requires transitive com.google.protobuf;
 
     exports org.phenopackets.schema.v1;
     exports org.phenopackets.schema.v1.core;

--- a/src/test/java/org/phenopackets/schema/v1/FamilyTest.java
+++ b/src/test/java/org/phenopackets/schema/v1/FamilyTest.java
@@ -16,14 +16,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class FamilyTest {
 
     @Test
-    void printFamilyAsYaml() throws IOException {
+    public void printFamilyAsYaml() throws IOException {
         Family family = TestExamples.rareDiseaseFamily();
         String json = JsonFormat.printer().print(family);
         System.out.println(FormatMapper.jsonToYaml(json));
     }
 
     @Test
-    void roundTrippingFamily() throws IOException {
+    public void roundTrippingFamily() throws IOException {
         Family original = TestExamples.rareDiseaseFamily();
 
         String json = JsonFormat.printer().print(original);

--- a/src/test/java/org/phenopackets/schema/v1/InterpretationTest.java
+++ b/src/test/java/org/phenopackets/schema/v1/InterpretationTest.java
@@ -9,10 +9,10 @@ import org.phenopackets.schema.v1.examples.TestExamples;
 /**
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  */
-class InterpretationTest {
+public class InterpretationTest {
 
     @Test
-    void interpretation() throws Exception {
+    public void interpretation() throws Exception {
         Diagnosis diagnosis = Diagnosis.newBuilder()
                 .setDisease(Disease.newBuilder()
                         .setTerm(

--- a/src/test/java/org/phenopackets/schema/v1/PhenopacketTest.java
+++ b/src/test/java/org/phenopackets/schema/v1/PhenopacketTest.java
@@ -12,17 +12,17 @@ import java.io.IOException;
 public class PhenopacketTest {
 
     @Test
-    void printCancer() throws IOException {
+    public void printCancer() throws IOException {
         System.out.println(PhenopacketFormat.toYaml(TestExamples.cancerPhenopacket()));
     }
 
     @Test
-    void printRareDisease() throws IOException {
+    public void printRareDisease() throws IOException {
         System.out.println(PhenopacketFormat.toJson(TestExamples.rareDiseasePhenopacket()));
     }
 
     @Test
-    void printBiosamples() throws IOException {
+    public void printBiosamples() throws IOException {
         System.out.println(PhenopacketFormat.toYaml(TestExamples.biosamplesPhenopacket()));
     }
 }

--- a/src/test/java/org/phenopackets/schema/v1/examples/ResourceOntologyClassExample.java
+++ b/src/test/java/org/phenopackets/schema/v1/examples/ResourceOntologyClassExample.java
@@ -18,7 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ResourceOntologyClassExample {
 
     @Test
-    void resolveUriForHpoClass() {
+    public void resolveUriForHpoClass() {
 
         Resource hpoResource = Resource.newBuilder()
                 // for OBO Ontologies, the value of this string MUST always be the official

--- a/src/test/java/org/phenopackets/schema/v1/examples/UrothelialCarcinomaExample.java
+++ b/src/test/java/org/phenopackets/schema/v1/examples/UrothelialCarcinomaExample.java
@@ -237,7 +237,7 @@ public class UrothelialCarcinomaExample {
 
 
     @Test
-    void testPatientName() {
+    public void testPatientName() {
         assertEquals(this.patientId, this.phenopacket.getSubject().getId());
     }
 

--- a/src/test/java/org/phenopackets/schema/v1/io/PhenopacketFormatTest.java
+++ b/src/test/java/org/phenopackets/schema/v1/io/PhenopacketFormatTest.java
@@ -12,10 +12,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  */
-class PhenopacketFormatTest {
+public class PhenopacketFormatTest {
 
     @Test
-    void roundTripping() throws IOException {
+    public void roundTripping() throws IOException {
         Phenopacket original = TestExamples.rareDiseasePhenopacket();
 
         String asYaml = PhenopacketFormat.toYaml(original);
@@ -29,7 +29,7 @@ class PhenopacketFormatTest {
     }
 
     @Test
-    void toFromJson() throws Exception {
+    public void toFromJson() throws Exception {
         Phenopacket original = TestExamples.cancerPhenopacket();
 
         String asJson = PhenopacketFormat.toJson(original);
@@ -39,7 +39,7 @@ class PhenopacketFormatTest {
     }
 
     @Test
-    void toFromYaml() throws Exception {
+    public void toFromYaml() throws Exception {
         Phenopacket original = TestExamples.biosamplesPhenopacket();
 
         String asYaml = PhenopacketFormat.toYaml(original);

--- a/src/test/java/org/phenopackets/schema/v2/examples/ResourceOntologyClassExample.java
+++ b/src/test/java/org/phenopackets/schema/v2/examples/ResourceOntologyClassExample.java
@@ -18,7 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ResourceOntologyClassExample {
 
     @Test
-    void resolveUriForHpoClass() {
+    public void resolveUriForHpoClass() {
 
         Resource hpoResource = Resource.newBuilder()
                 // for OBO Ontologies, the value of this string MUST always be the official

--- a/src/test/java/org/phenopackets/schema/v2/examples/UrothelialCarcinomaExample.java
+++ b/src/test/java/org/phenopackets/schema/v2/examples/UrothelialCarcinomaExample.java
@@ -236,7 +236,7 @@ public class UrothelialCarcinomaExample {
 
 
     @Test
-    void testPatientName() {
+    public void testPatientName() {
         assertEquals(this.patientId, this.phenopacket.getSubject().getId());
     }
 

--- a/src/test/java/org/phenopackets/schema/v2/io/PhenopacketFormatTest.java
+++ b/src/test/java/org/phenopackets/schema/v2/io/PhenopacketFormatTest.java
@@ -12,10 +12,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  */
-class PhenopacketFormatTest {
+public class PhenopacketFormatTest {
 
     @Test
-    void roundTripping() throws IOException {
+    public void roundTripping() throws IOException {
         Phenopacket original = TestExamples.rareDiseasePhenopacket();
 
         String asYaml = PhenopacketFormat.toYaml(original);
@@ -29,7 +29,7 @@ class PhenopacketFormatTest {
     }
 
     @Test
-    void toFromJson() throws Exception {
+    public void toFromJson() throws Exception {
         Phenopacket original = TestExamples.cancerPhenopacket();
 
         String asJson = PhenopacketFormat.toJson(original);
@@ -39,7 +39,7 @@ class PhenopacketFormatTest {
     }
 
     @Test
-    void toFromYaml() throws Exception {
+    public void toFromYaml() throws Exception {
         Phenopacket original = TestExamples.biosamplesPhenopacket();
 
         String asYaml = PhenopacketFormat.toYaml(original);


### PR DESCRIPTION
Dear Phenopacket Schema development team, 
I'd like to propose adding `module-info.java` file into the project to make Phenopacket Schema a first-class citizen in the Java modular world.

The PR is really a draft, a bare minimum to make the build pass.